### PR TITLE
Configure release-drafter to ignore patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+    labels:
+      - "patch"

--- a/.github/ranger.yml
+++ b/.github/ranger.yml
@@ -1,0 +1,2 @@
+merges:
+  - action: delete_branch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,6 +9,8 @@ categories:
   - title: '📚Dependency Updates'
     labels:
       - 'dependencies'
+exclude-labels:
+  - 'patch'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 template: |
   ## What’s Changed


### PR DESCRIPTION
## Summary
To reduce noise in the `CHANGELOG.md`, ignore patch dependency updates.