### PR TITLE
adds readme back to the vscode deploy

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,7 +7,6 @@ node_modules/**
 out/**
 src/**
 .gitignore
-**/*.md
 snippet.conf
 tsconfig.json
 tslint.json


### PR DESCRIPTION
This is causing the extension page in the marketplace to appear blank as the README is excluded in the general markdown file filter. 